### PR TITLE
Tweak to match the clojars namespace

### DIFF
--- a/src/leiningen/jupyter/kernel.clj
+++ b/src/leiningen/jupyter/kernel.clj
@@ -7,7 +7,7 @@
 
 (defn run-kernel [project argv]
   (let [curr-deps (or (:dependencies project) [])
-        new-deps (conj curr-deps ['clojupyter "0.1.0"])
+        new-deps (conj curr-deps ['org.clojars.didiercrunch/clojupyter "0.1.0"])
         prj (assoc project :dependencies new-deps)]
     (eval/eval-in-project prj
                           (conj (list argv) `clojupyter.core/-main)


### PR DESCRIPTION
I think that it may need the namespace to find it on clojars if it is not already in your local maven.

Thanks for great work 😸 